### PR TITLE
Add note about potential sqlx runtime feature conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 > NOTE: SQL Builders are typically not used directly by application business logic, but rather to be wrapped in some Application Model Access Layer (e.g., DAOs or MCs - Model Controller - patterns). Even when using ORMs, it is often a good code design to wrap those access via some model access layers. 
 
+> NOTE: sqlb has the feature `runtime-tokio-rustls` enabled by the sqlx crate. Do not enable a conflicting runtime feature when adding sqlx to your project.
 
 Goals for first **0.x.x** releases: 
 


### PR DESCRIPTION
Update read to include a note about how sqlb adds a runtime feature for sqlx so if someone includes sqlx in their crate they can't have conflicting runtime features.

Addresses issue #2 