### PR TITLE
feat: added chrono support as optional feature and extend bindable!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ sqlb-macros = { version="0.3.2", path = "sqlb-macros" }
 async-trait = "0.1"
 time = "0.3.20"
 uuid = "1.3.1"
+chrono = { version = "0.4", optional = true }
+
+[features]
+default = []
+chrono-support = ["chrono"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/val.rs
+++ b/src/val.rs
@@ -20,23 +20,23 @@ pub trait SqlxBindable: std::fmt::Debug {
 
 #[macro_export]
 macro_rules! bindable {
-	($($t:ident),*) => {
-		$(impl $crate::SqlxBindable for $t {
-			fn bind_query<'q>(&self, query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-				let query = query.bind(self.clone());
-				query
-			}
-		}
+    ($($t:ty),*) => {
+        $(impl $crate::SqlxBindable for $t {
+            fn bind_query<'q>(&self, query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+                let query = query.bind(self.clone());
+                query
+            }
+        }
 
-		impl $crate::SqlxBindable for &$t {
-			fn bind_query<'q>(&self, query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-				let query = query.bind(<$t>::clone(self));
-				query
-			}
-		}
+        impl $crate::SqlxBindable for &$t {
+            fn bind_query<'q>(&self, query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+                let query = query.bind(<$t>::clone(self));
+                query
+            }
+        }
 
-		)*
-	};
+        )*
+    };
 }
 
 #[macro_export]
@@ -87,6 +87,16 @@ bindable!(i8, i16, i32, i64, f32, f64);
 bindable!(Uuid, OffsetDateTime);
 
 // region:    --- Raw Value
+
+// region: 		--- chrono support
+#[cfg(feature = "chrono-support")]
+mod chrono_support {
+	use chrono::{NaiveDateTime, NaiveDate, NaiveTime, DateTime, Utc};
+
+	bindable!(NaiveDateTime, NaiveDate, NaiveTime, DateTime<Utc>);
+}
+// endregion: --- chrono support
+
 
 #[derive(Debug)]
 pub struct Raw(pub &'static str);


### PR DESCRIPTION
**Description:**

Enhances the bindable! macro to handle Rust types that require type parameters. This is a significant improvement because it allows us to use the bindable! macro with complex types that have parameters, like chrono::DateTime<chrono::Utc>.

**Changes:**

1. Update bindable! Macro: The bindable! macro has been modified to accept a type parameter. Previously, it was not capable of handling Rust types with parameters. This update makes the macro more versatile and broadens its applicability.
2.  Add Chrono Support Module: added a new module chrono_support that uses our updated bindable! macro to handle the DateTime<Utc>, NaiveDateTime, NaiveDate, and NaiveTime types from the chrono crate. This enhancement allows our application to correctly bind these types when constructing SQL queries, ensuring accurate and efficient interaction with the PostgreSQL database.

**Tests**
I have run `cargo test` and everything seem to be working fine and passed.

Note: I am new to rust so if there is anything I did wrong or can be improved do let me know.