### PR TITLE
feat: added `serde_json::Value` support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,12 @@ async-trait = "0.1"
 time = "0.3.20"
 uuid = "1.3.1"
 chrono = { version = "0.4", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [features]
 default = []
 chrono-support = ["chrono"]
+json = ["serde_json"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ time = "0.3.20"
 uuid = "1.3.1"
 chrono = { version = "0.4", optional = true }
 serde_json = { version = "1.0", optional = true }
+rust_decimal = { version = "1.34", optional = true }
 
 [features]
 default = []
 chrono-support = ["chrono"]
 json = ["serde_json"]
+decimal = ["rust_decimal", "sqlx:rust_decimal"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/val.rs
+++ b/src/val.rs
@@ -97,6 +97,15 @@ mod chrono_support {
 }
 // endregion: --- chrono support
 
+// region: 		--- json support
+#[cfg(feature = "json")]
+mod json {
+    use serde_json::Value;
+
+	bindable!(Value);
+}
+// endregion: --- json support
+
 
 #[derive(Debug)]
 pub struct Raw(pub &'static str);

--- a/src/val.rs
+++ b/src/val.rs
@@ -106,6 +106,14 @@ mod json {
 }
 // endregion: --- json support
 
+// region: 		--- decimal support
+#[cfg(feature = "decimal")]
+mod decimal {
+    use rust_decimal::Decimal;
+
+	bindable!(Decimal);
+}
+// endregion: --- decimal support
 
 #[derive(Debug)]
 pub struct Raw(pub &'static str);


### PR DESCRIPTION
Added `serde_json::Value` support using `bindable!` macro.

I wasn't able to figure out how to add the other json types supported by `sqlx`.